### PR TITLE
added options parameter to filter for devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To retrieve client id and secret please follow following guide:
 
 # Advanced Configuration
 
-Ther are some optioal configuration options in the netatmo section of the config which provide finer control about what device and services to use to create accessories.
+There are some optional configuration options in the netatmo section of the config which provide finer control about what device and services to use to create accessories.
 
 ## Control Accessories by device type
 

--- a/devices/weatherstation.js
+++ b/devices/weatherstation.js
@@ -61,7 +61,9 @@ var WeatherStationDevice = function(log, api, config) {
 inherits(WeatherStationDevice, NetatmoDevice);
 
 WeatherStationDevice.prototype.refresh = function (callback) {
-  this.api.getStationsData(function (err, devices) {
+  var options = this.config["options_weather"]
+ 
+  this.api.getStationsData(options, function (err, devices) {
     // querying for the device infos and the main module
     var i, device, len = devices.length;
     var weatherstations = {};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"homebridge": ">=0.3.4"
 	},
 	"dependencies": {
-		"netatmo": "git+https://github.com/karbassi/netatmo.git#v1.5.0",
+		"netatmo": "git+https://github.com/karbassi/netatmo.git#v1.6.0",
 		"node-cache": "3.0.0",
 		"async": "2.0.1",
 		"glob": "7.0.5"


### PR DESCRIPTION
I have added a feature to filter for specific netatmo devices. You have to add the following config to your config.json

{   
            "platform": "netatmo",
            "name": "Netatmo Weather",
            "ttl": 5,
            "options_weather": {
                "device_id": "XX:XX:XX:XX:XX:XX"
            },  
            "auth": {
                "client_id": "",
                "client_secret": "",
                "username": "",
                "password": ""
            }   
        }