### PR TITLE
Better/consistent use of homebridge logging

### DIFF
--- a/devices/thermostat.js
+++ b/devices/thermostat.js
@@ -62,7 +62,7 @@ ThermostatDevice.prototype.refresh = function (callback) {
       device.module_name = device.station_name; // Multiple ??
       // device.module_name = device.station_name + " " + device.module_name
 
-      this.log("refreshing thermostat device " + device._id + " (" + device.module_name + ")");
+      this.log.debug("Refreshing thermostat device " + device._id + " (" + device.module_name + ")");
       accessoryDataSources[device._id] = device;
 
     }

--- a/devices/weatherstation.js
+++ b/devices/weatherstation.js
@@ -75,7 +75,7 @@ WeatherStationDevice.prototype.refresh = function (callback) {
       device = stationModuleData[i];
       device.module_name = device.station_name + " " + device.module_name
 
-      this.log("refreshing weatherstation device " + device._id + " (" + device.module_name + ")");
+      this.log.debug("Refreshing weatherstation device " + device._id + " (" + device.module_name + ")");
       accessoryDataSources[device._id] = device;
 
       // querying for the extra modules
@@ -83,7 +83,7 @@ WeatherStationDevice.prototype.refresh = function (callback) {
       for (var j = 0; j < modulecount; j++) {
         var module = device.modules[j];
         module.module_name = device.station_name + " " + module.module_name
-        this.log("refreshing weatherstation module " + module._id + " (" + module.module_name + ")");
+        this.log.debug("Refreshing weatherstation module " + module._id + " (" + module.module_name + ")");
         accessoryDataSources[module._id] = module;
       }
     }

--- a/devices/welcome.js
+++ b/devices/welcome.js
@@ -63,7 +63,7 @@ WelcomeDevice.prototype.refresh = function (callback) {
       home.firmware = "0.0";
       home.type="welcome";
 
-      this.log("refreshing welcome device " + home._id + " (" + home.module_name + ")");
+      this.log.debug("Refreshing welcome device " + home._id + " (" + home.module_name + ")");
       accessoryDataSources[home._id] = home;
     }
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ function NetatmoPlatform(log, config) {
   this.config = config;
 
   // If this log message is not seen, most likely the config.js is not found.
-  this.log('Creating NetatmoPlatform...');
+  // although the line before will tell the tale, viz., "Initializing netatmo platform"
+  this.log.debug('Creating NetatmoPlatform...');
 
   if (config.mockapi) {
     this.log('CAUTION! USING FAKE NETATMO API: ' + config.mockapi);
@@ -35,10 +36,10 @@ function NetatmoPlatform(log, config) {
     this.api = new netatmo(config["auth"]);
   }
   this.api.on("error", function (error) {
-    that.log('ERROR - Netatmo: ' + error);
+    that.log.error('ERROR - Netatmo: ' + error);
   });
   this.api.on("warning", function (error) {
-    that.log('WARN - Netatmo: ' + error);
+    that.log.warn('WARN - Netatmo: ' + error);
   });
 }
 

--- a/lib/netatmo-accessory.js
+++ b/lib/netatmo-accessory.js
@@ -59,8 +59,8 @@ var NetatmoAccessory = function(stationData, netAtmoDevice) {
         }
       }
     } catch (err) {
-      this.log("Could not process file " + file);
-      this.log(err);
+      this.log.error("Could not process file " + file);
+      this.log.error(err);
       this.log(err.stack); 
     }
   }.bind(this));


### PR DESCRIPTION
1. use `log.debug` for verbose entries, and `log.error` / `log.warn` as appropriate
2. always start a log entry with a capital letter (seems to be doing that every else in homebridge)
