### PR TITLE
Change Cool Mode from Frost-guard to Away

### DIFF
--- a/accessory/thermostat-accessory.js
+++ b/accessory/thermostat-accessory.js
@@ -126,7 +126,7 @@ module.exports = function(pHomebridge) {
       if(thermostatData.mode && this.mode != thermostatData.mode) {
         this.mode = thermostatData.mode;
         switch(this.mode) {
-          case 'hg':
+          case 'away':
             this.targetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.COOL;
             break;
           case 'max':


### PR DESCRIPTION
Since manual set points get reset by Netatmo api after a certain time, being able to trigger the away would allow you to make automations for when the house is empty on a work day or a long weekend. Away trigger remains in place until turned off.

Frost-guard is not very useful for automation, so it could be relegated to the Netatmo app itself.