### PR TITLE
Fix for: [homebridge-netatmo] This plugin generated a warning from the characteristic 'Atmospheric Pressure'

### DIFF
--- a/service/weatherstation-airpressure-legacy.js
+++ b/service/weatherstation-airpressure-legacy.js
@@ -25,7 +25,7 @@ module.exports = function(pHomebridge) {
     constructor(accessory) {
       super('Atmospheric Pressure', ATMOSPHERIC_PRESSURE_CTYPE_ID);
       this.setProps({
-        format: Characteristic.Formats.UINT8,
+        format: Characteristic.Formats.UINT16,
         unit: "hPA", 
         minValue: 500,
         maxValue: 2000,


### PR DESCRIPTION
I changed the characteristic Atmospheric Pressure to UINT16 to display values above 255
Atmospheric pressure is usually around 1000+/- so it is probably best to use a UINT16