### PR TITLE
Update weatherstation-airpressure-legacy.js

### DIFF
--- a/service/weatherstation-airpressure-legacy.js
+++ b/service/weatherstation-airpressure-legacy.js
@@ -25,7 +25,7 @@ module.exports = function(pHomebridge) {
     constructor(accessory) {
       super('Atmospheric Pressure', ATMOSPHERIC_PRESSURE_CTYPE_ID);
       this.setProps({
-        format: Characteristic.Formats.UINT8,
+        format: Characteristic.Formats.UINT16,
         unit: "hPA", 
         minValue: 500,
         maxValue: 2000,


### PR DESCRIPTION
Changed line 28 from UINT8 to UINT16 to solve warning related with illegal value of air pressure

[homebridge-netatmo] This plugin generated a warning from the characteristic 'Atmospheric Pressure': characteristic was supplied illegal value: number 1015 exceeded maximum of 255. See https://homebridge.io/w/JtMGR for more info.